### PR TITLE
Supports urls with "//" prefix but no protocol (e.g. '//localhost:300…

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -12,6 +12,7 @@ export const originRegEx = new RegExp(origin)
  * @return {string} URL sans origin and sans leading comma
  */
 export const sanitize = url => {
+  if ( /^\/\//.test(url) ) url = document.location.protocol + url
   let route = url.replace(originRegEx, '')
   let clean = route.match(/^\//) ? route.replace(/\/{1}/,'') : route // remove /
   return clean === '' ? '/' : clean


### PR DESCRIPTION
…0/index/php?post=name')

This is a weird use case. I have a proxy'd environment where the proxy creates urls like the above. It only breaks when I use operator.js, not with a normal (non-XHR) page request.